### PR TITLE
Expose City and Role constructors from SalaryCalculator module

### DIFF
--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -1,4 +1,10 @@
-module SalaryCalculator exposing (ljubljana, main, salary, softwareEngineer, tenureDetail)
+module SalaryCalculator exposing
+    ( City(..)
+    , Role(..)
+    , main
+    , salary
+    , tenureDetail
+    )
 
 import Bootstrap.Accordion as Accordion
 import Bootstrap.Button as Button
@@ -797,18 +803,3 @@ main =
         , view = view
         , subscriptions = subscriptions
         }
-
-
-
--- TEST HELPERS
--- Hopefully these can be removed
-
-
-softwareEngineer : Role
-softwareEngineer =
-    SoftwareEngineer
-
-
-ljubljana : City
-ljubljana =
-    Ljubljana

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -4,7 +4,13 @@ import Bootstrap.Accordion as Accordion
 import Bootstrap.Dropdown as Dropdown
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
-import SalaryCalculator exposing (ljubljana, salary, softwareEngineer, tenureDetail)
+import SalaryCalculator
+    exposing
+        ( City(..)
+        , Role(..)
+        , salary
+        , tenureDetail
+        )
 import Test exposing (..)
 
 
@@ -17,8 +23,8 @@ defaultSalary =
                 , cityDropdown = Dropdown.initialState
                 , tenureDropdown = Dropdown.initialState
                 , accordionState = Accordion.initialState
-                , role = softwareEngineer
-                , city = ljubljana
+                , role = SoftwareEngineer
+                , city = Ljubljana
                 , tenure = 2
                 }
                 |> Expect.equal 5017


### PR DESCRIPTION
So that in tests we can use them directly. No need to make wrapper 
functions - type constructors are functions themselves.