### PR TITLE
Implement tests for tenure impact on salary

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,6 +10,7 @@
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
             "elm/url": "1.0.0",
+            "elm-community/list-extra": "8.1.0",
             "elm-community/maybe-extra": "5.0.0",
             "rundis/elm-bootstrap": "5.1.0"
         },
@@ -25,10 +26,9 @@
             "elm-explorations/test": "1.2.1"
         },
         "indirect": {
+            "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/svg": "1.0.1",
-            "elm-community/list-extra": "8.1.0",
-            "elm/random": "1.0.0"
+            "elm/svg": "1.0.1"
         }
     }
 }

--- a/elm.json
+++ b/elm.json
@@ -10,7 +10,6 @@
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
             "elm/url": "1.0.0",
-            "elm-community/list-extra": "8.1.0",
             "elm-community/maybe-extra": "5.0.0",
             "rundis/elm-bootstrap": "5.1.0"
         },
@@ -23,7 +22,8 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.1"
+            "elm-explorations/test": "1.2.1",
+            "elm-community/list-extra": "8.1.0"
         },
         "indirect": {
             "elm/random": "1.0.0",

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -1,7 +1,10 @@
 module SalaryCalculator exposing
     ( City(..)
     , Role(..)
+    , cityDetail
+    , init
     , main
+    , roleDetail
     , salary
     , tenureDetail
     )


### PR DESCRIPTION
This PR introduces:

- [x] 6500 tests asserting that for every role in every city for every year (from 0 to 25) the salary will increase;
- [x] 5000 tests asserting that employees living in more expensive cities earn more.

The tests are generated (roles x cities x [ 1 ... 25 ] years of tenure)