### PR TITLE
Setup doc tests using Elm Verify Examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ elm-stuff/
 node_modules/
 repl-temp-*
 .npmrc
+/tests/VerifyExamples

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ codecov: .coverage/codecov.json
 
 # Build distribution files and place them where they are expected
 .PHONY: dist
-dist: .installed tests
+dist: .installed
 	# For modules (commonjs or ES6)
 	@npx parcel build src/index.js
 	# For html script tags

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ codecov: .coverage/codecov.json
 
 # Build distribution files and place them where they are expected
 .PHONY: dist
-dist: .installed
+dist: .installed tests
 	# For modules (commonjs or ES6)
 	@npx parcel build src/index.js
 	# For html script tags

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,17 @@ lint: .installed
 test: tests
 
 .PHONY: tests
-tests: .installed
+tests: .installed doc-tests coverage
+
+.PHONY: coverage
+coverage:
 	@npx elm-coverage --report codecov
+
+.PHONY: doc-tests
+doc-tests: .installed
 	@npx elm-verify-examples
 
-.coverage/codecov.json: .installed test
+.coverage/codecov.json: .installed coverage
 
 # Run development server
 .PHONY: run

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test: tests
 .PHONY: tests
 tests: .installed
 	@npx elm-coverage --report codecov
+	@npx elm-verify-examples
 
 .coverage/codecov.json: .installed test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3658,6 +3658,698 @@
         }
       }
     },
+    "elm-verify-examples": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/elm-verify-examples/-/elm-verify-examples-3.1.0.tgz",
+      "integrity": "sha512-zNjiwP8vR83caUDKXa+BK3S9wLxLy5DB/2qDfewI5OuEevv+QwZUh1sSZbhNtkgKYdL7pLFX0s+Sp5tvAbJoCQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "elm-test": "0.19.0-rev6",
+        "fs-extra": "^5.0.0",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.2",
+        "yargs": "^10.0.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz",
+          "integrity": "sha1-glR3SrR4a4xbPPTfumbOVjkywlI=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "elm-test": {
+          "version": "0.19.0-rev6",
+          "resolved": "https://registry.npmjs.org/elm-test/-/elm-test-0.19.0-rev6.tgz",
+          "integrity": "sha512-Qdy9QusZF+eT0203XBiT1Y/UhFeUjcSuyyzf3iyp32dsYpAfcoDTWHjlBVjia1CyvFauESQ4pc81nKaq6snClg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "chokidar": "2.1.2",
+            "cross-spawn": "4.0.0",
+            "elmi-to-json": "0.19.1",
+            "find-parent-dir": "^0.3.0",
+            "firstline": "1.2.1",
+            "fs-extra": "0.30.0",
+            "fsevents": "1.2.4",
+            "glob": "7.1.1",
+            "lodash": "4.17.11",
+            "minimist": "^1.2.0",
+            "murmur-hash-js": "1.0.0",
+            "node-elm-compiler": "5.0.3",
+            "split": "1.0.1",
+            "supports-color": "4.2.0",
+            "temp": "0.8.3",
+            "which": "1.3.1",
+            "xmlbuilder": "^8.2.2"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+              "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+              }
+            },
+            "fs-extra": {
+              "version": "0.30.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+              "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
+              }
+            }
+          }
+        },
+        "elmi-to-json": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/elmi-to-json/-/elmi-to-json-0.19.1.tgz",
+          "integrity": "sha512-O0Z3YsYU9OTb1hTDGORWxi69QjQFEIPfZVq/oc1D5lhL3swduHKY8vdKGuo+WlKVdTas99oNIsgL7yojWdYcsQ==",
+          "dev": true,
+          "requires": {
+            "binwrap": "^0.2.0-rc2"
+          }
+        },
+        "firstline": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.2.1.tgz",
+          "integrity": "sha1-uIZzxCAJ+IIfrCkm6ZcgrO6ST64=",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          },
+          "dependencies": {
+            "jsonfile": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+              "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6"
+              }
+            }
+          }
+        },
+        "fsevents": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+          "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.21",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.7",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.2.4",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
+          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
+      }
+    },
     "elmi-to-json": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/elmi-to-json/-/elmi-to-json-0.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "elm-analyse": "^0.16.1",
     "elm-coverage": "^0.2.0",
     "elm-hot": "^1.0.1",
+    "elm-verify-examples": "^3.1.0",
     "node-elm-compiler": "^5.0.3",
     "parcel-bundler": "^1.12.0"
   }

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -6,6 +6,7 @@ module SalaryCalculator exposing
     , init
     , main
     , roleDetail
+    , roleFromString
     , salary
     , tenureDetail
     )
@@ -296,6 +297,15 @@ type Role
     | CustomerSupportSpecialist
 
 
+{-| Parses a Role from a String representation. Useful for parsing query parameters. If the name is not recognized returns Nothing.
+
+    roleFromString "SeniorOperationsManager"
+    --> Just SeniorOperationsManager
+
+    roleFromString "Ranger"
+    --> Nothing
+
+-}
 roleFromString : String -> Maybe Role
 roleFromString role =
     case role of

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -187,6 +187,14 @@ type alias CityDetail =
     }
 
 
+{-| Given a City returns a CityDetail record containing a human readable name and a location factor for calculating salary.
+
+    cityDetail NoviSad
+    --> { name = "Novi Sad"
+    --> , locationFactor = 0.82
+    --> }
+
+-}
 cityDetail : City -> CityDetail
 cityDetail city =
     case city of

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -379,6 +379,14 @@ type alias RoleDetail =
     }
 
 
+{-| Given a Role returns a RoleDetail record containing a human readable name of a role and a base salary.
+
+    roleDetail SoftwareEngineer
+    --> { name = "Software Engineer"
+    --> , baseSalary = 4919
+    --> }
+
+-}
 roleDetail : Role -> RoleDetail
 roleDetail role =
     case role of
@@ -489,6 +497,14 @@ type alias TenureDetail =
     }
 
 
+{-| Given an Int representing number of years returns a TenureDetail record containing a human readable description of the period and a commitment bonus.
+
+    tenureDetail 5
+    --> { name = "5 years"
+    --> , commitmentBonus = 0.1791759469228055
+    --> }
+
+-}
 tenureDetail : Int -> TenureDetail
 tenureDetail years =
     let

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -127,7 +127,10 @@ type City
     | Kharkiv
 
 
-{-| Parses a City from a String representation of it's name. Useful for parsing query parameters. If the name is not recognized returns Nothing.
+{-| Parses a City from a String representation of it's name.
+
+Useful for parsing query parameters. If the name is not recognized returns
+Nothing.
 
     cityFromString "NoviSad"
     --> Just NoviSad
@@ -188,7 +191,10 @@ type alias CityDetail =
     }
 
 
-{-| Given a City returns a CityDetail record containing a human readable name and a location factor for calculating salary.
+{-| Given a City returns a CityDetail record.
+
+The record contains a human readable name and a location factor for calculating
+salary.
 
     cityDetail NoviSad
     --> { name = "Novi Sad"
@@ -297,7 +303,10 @@ type Role
     | CustomerSupportSpecialist
 
 
-{-| Parses a Role from a String representation. Useful for parsing query parameters. If the name is not recognized returns Nothing.
+{-| Parses a Role from a String representation.
+
+Useful for parsing query parameters. If the name is not recognized returns
+Nothing.
 
     roleFromString "SeniorOperationsManager"
     --> Just SeniorOperationsManager
@@ -379,7 +388,9 @@ type alias RoleDetail =
     }
 
 
-{-| Given a Role returns a RoleDetail record containing a human readable name of a role and a base salary.
+{-| Given a Role returns a RoleDetail record.
+
+The record contains a human readable name of a role and a base salary.
 
     roleDetail SoftwareEngineer
     --> { name = "Software Engineer"
@@ -497,7 +508,10 @@ type alias TenureDetail =
     }
 
 
-{-| Given an Int representing number of years returns a TenureDetail record containing a human readable description of the period and a commitment bonus.
+{-| Given an Int representing number of years returns a TenureDetail record.
+
+The record contains a human readable description of the period and a commitment
+bonus.
 
     tenureDetail 5
     --> { name = "5 years"

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -191,7 +191,7 @@ type alias CityDetail =
 
     cityDetail NoviSad
     --> { name = "Novi Sad"
-    --> , locationFactor = 0.82
+    --> , locationFactor = 0.81
     --> }
 
 -}

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -2,6 +2,7 @@ module SalaryCalculator exposing
     ( City(..)
     , Role(..)
     , cityDetail
+    , cityFromString
     , init
     , main
     , roleDetail
@@ -125,6 +126,15 @@ type City
     | Kharkiv
 
 
+{-| Parses a City from a String representation of it's name. Useful for parsing query parameters. If the name is not recognized returns Nothing.
+
+    cityFromString "NoviSad"
+    --> Just NoviSad
+
+    cityFromString "MinasTirith"
+    --> Nothing
+
+-}
 cityFromString : String -> Maybe City
 cityFromString city =
     case city of

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -1,0 +1,4 @@
+{
+  "root": "../src/",
+  "tests": [ "SalaryCalculator" ]
+}


### PR DESCRIPTION
This PR introduces the setup for doc tests using [Elm Validate Examples](https://github.com/stoeffel/elm-verify-examples) and few doc comments with examples to run.

**Notes**

The obvious omission is an example for `salary` function. It is the core business logic of this program. Before we write it I would like to address #24 and related #24. I would suggest to merge this and work on the issues in a separate PR.

Unfortunately the doc tests currently do not get counted in coverage report. This is due to how Elm Validate Examples work. To change this first that issue would have to be addressed: https://github.com/stoeffel/elm-verify-examples/issues/65

Another improvement would be to follow the advise here https://github.com/elm-explorations/test/tree/1.2.1#application-specific-techniques and not expose all the internal helpers from Main module. We could create several specialized modules like `Salary`, `City`, `Tenure` or just one `Internal` with everything exposed and one `Main` which would only expose `main`. IMO this goes beyond the scope of this PR. Maybe we should make an issue for that?