### PR TITLE
Dynamic configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,100 @@
+cities:
+  - name: San Francisco
+    locationFactor: 1.59
+
+  - name: London
+    locationFactor: 1.3
+
+  - name: Amsterdam
+    locationFactor: 1.2
+
+  - name: Berlin
+    locationFactor: 0.99
+
+  - name: Barcelona
+    locationFactor: 0.97
+
+  - name: Lisbon
+    locationFactor: 0.94
+
+  - name: Ljubljana
+    locationFactor: 0.91
+
+  - name: Maribor
+    locationFactor: 0.86
+
+  - name: Bucharest
+    locationFactor: 0.84
+
+  - name: Novi Sad
+    locationFactor: 0.81
+
+  - name: Davao
+    locationFactor: 0.81
+
+  - name: Delhi
+    locationFactor: 0.79
+
+  - name: Kharkiv
+    locationFactor: 0.79
+
+roles:
+  - name: Principal Software Engineer
+    baseSalary: 6184
+
+  - name: Lead Software Engineer
+    baseSalary: 5791
+
+  - name: Software Engineer
+    baseSalary: 4919
+
+  - name: Junior Software Engineer
+    baseSalary: 3795
+
+  - name: Junior Programmer
+    baseSalary: 2506
+
+  - name: Senior Product Marketing Manager
+    baseSalary: 6140
+
+  - name: Product Marketing Manager
+    baseSalary: 5243
+
+  - name: Senior Digital Marketing Specialist
+    baseSalary: 3693
+
+  - name: Digital Marketing Specialist
+    baseSalary: 2955
+
+  - name: Marketing Associate
+    baseSalary: 2446
+
+  - name: Principal Designer
+    baseSalary: 5371
+
+  - name: Lead Designer
+    baseSalary: 4206
+
+  - name: Senior Designer
+    baseSalary: 4066
+
+  - name: Designer
+    baseSalary: 3119
+
+  - name: Junior Designer
+    baseSalary: 2649
+
+  - name: Senior Operations Manager
+    baseSalary: 3903
+
+  - name: Operations Manager
+    baseSalary: 2720
+
+  - name: Technical Support Specialist
+    baseSalary: 1979
+
+  - name: Customer Support Associate
+    baseSalary: 1792
+
+  - name: Customer Support Specialist
+    baseSalary: 1711

--- a/config.yml
+++ b/config.yml
@@ -1,33 +1,16 @@
 cities:
-  - name: San Francisco
-    locationFactor: 1.59
-
-  - name: London
-    locationFactor: 1.3
 
   - name: Amsterdam
     locationFactor: 1.2
 
-  - name: Berlin
-    locationFactor: 0.99
-
   - name: Barcelona
     locationFactor: 0.97
 
-  - name: Lisbon
-    locationFactor: 0.94
-
-  - name: Ljubljana
-    locationFactor: 0.91
-
-  - name: Maribor
-    locationFactor: 0.86
+  - name: Berlin
+    locationFactor: 0.99
 
   - name: Bucharest
     locationFactor: 0.84
-
-  - name: Novi Sad
-    locationFactor: 0.81
 
   - name: Davao
     locationFactor: 0.81
@@ -38,71 +21,94 @@ cities:
   - name: Kharkiv
     locationFactor: 0.79
 
+  - name: Lisbon
+    locationFactor: 0.94
+
+  - name: Ljubljana
+    locationFactor: 0.91
+
+  - name: London
+    locationFactor: 1.3
+
+  - name: Maribor
+    locationFactor: 0.86
+
+  - name: Novi Sad
+    locationFactor: 0.81
+
+  - name: San Francisco
+    locationFactor: 1.59
+
 careers:
-  - name: Technical
-    roles:
-      - name: Principal Software Engineer
-        baseSalary: 6184
-
-      - name: Lead Software Engineer
-        baseSalary: 5791
-
-      - name: Software Engineer
-        baseSalary: 4919
-
-      - name: Junior Software Engineer
-        baseSalary: 3795
-
-      - name: Junior Programmer
-        baseSalary: 2506
-
-  - name: Marketing
-    roles:
-      - name: Senior Product Marketing Manager
-        baseSalary: 6140
-
-      - name: Product Marketing Manager
-        baseSalary: 5243
-
-      - name: Senior Digital Marketing Specialist
-        baseSalary: 3693
-
-      - name: Digital Marketing Specialist
-        baseSalary: 2955
-
-      - name: Marketing Associate
-        baseSalary: 2446
 
   - name: Design
     roles:
-      - name: Principal Designer
-        baseSalary: 5371
-
-      - name: Lead Designer
-        baseSalary: 4206
-
-      - name: Senior Designer
-        baseSalary: 4066
+      - name: Junior Designer
+        baseSalary: 2649
 
       - name: Designer
         baseSalary: 3119
 
-      - name: Junior Designer
-        baseSalary: 2649
+      - name: Senior Designer
+        baseSalary: 4066
+
+      - name: Lead Designer
+        baseSalary: 4206
+
+      - name: Principal Designer
+        baseSalary: 5371
+
+
+  - name: Marketing
+    roles:
+      - name: Marketing Associate
+        baseSalary: 2446
+
+      - name: Digital Marketing Specialist
+        baseSalary: 2955
+
+      - name: Senior Digital Marketing Specialist
+        baseSalary: 3693
+
+      - name: Product Marketing Manager
+        baseSalary: 5243
+
+      - name: Senior Product Marketing Manager
+        baseSalary: 6140
+
 
   - name: Operations
     roles:
-      - name: Senior Operations Manager
-        baseSalary: 3903
-
-      - name: Operations Manager
-        baseSalary: 2720
-
-      - name: Technical Support Specialist
-        baseSalary: 1979
+      - name: Customer Support Specialist
+        baseSalary: 1711
 
       - name: Customer Support Associate
         baseSalary: 1792
 
-      - name: Customer Support Specialist
-        baseSalary: 1711
+      - name: Technical Support Specialist
+        baseSalary: 1979
+
+      - name: Operations Manager
+        baseSalary: 2720
+
+      - name: Senior Operations Manager
+        baseSalary: 3903
+
+
+  - name: Technical
+    roles:
+      - name: Junior Programmer
+        baseSalary: 2506
+
+      - name: Junior Software Engineer
+        baseSalary: 3795
+
+      - name: Software Engineer
+        baseSalary: 4919
+
+      - name: Lead Software Engineer
+        baseSalary: 5791
+
+      - name: Principal Software Engineer
+        baseSalary: 6184
+

--- a/config.yml
+++ b/config.yml
@@ -38,63 +38,71 @@ cities:
   - name: Kharkiv
     locationFactor: 0.79
 
-roles:
-  - name: Principal Software Engineer
-    baseSalary: 6184
+careers:
+  - name: Technical
+    roles:
+      - name: Principal Software Engineer
+        baseSalary: 6184
 
-  - name: Lead Software Engineer
-    baseSalary: 5791
+      - name: Lead Software Engineer
+        baseSalary: 5791
 
-  - name: Software Engineer
-    baseSalary: 4919
+      - name: Software Engineer
+        baseSalary: 4919
 
-  - name: Junior Software Engineer
-    baseSalary: 3795
+      - name: Junior Software Engineer
+        baseSalary: 3795
 
-  - name: Junior Programmer
-    baseSalary: 2506
+      - name: Junior Programmer
+        baseSalary: 2506
 
-  - name: Senior Product Marketing Manager
-    baseSalary: 6140
+  - name: Marketing
+    roles:
+      - name: Senior Product Marketing Manager
+        baseSalary: 6140
 
-  - name: Product Marketing Manager
-    baseSalary: 5243
+      - name: Product Marketing Manager
+        baseSalary: 5243
 
-  - name: Senior Digital Marketing Specialist
-    baseSalary: 3693
+      - name: Senior Digital Marketing Specialist
+        baseSalary: 3693
 
-  - name: Digital Marketing Specialist
-    baseSalary: 2955
+      - name: Digital Marketing Specialist
+        baseSalary: 2955
 
-  - name: Marketing Associate
-    baseSalary: 2446
+      - name: Marketing Associate
+        baseSalary: 2446
 
-  - name: Principal Designer
-    baseSalary: 5371
+  - name: Design
+    roles:
+      - name: Principal Designer
+        baseSalary: 5371
 
-  - name: Lead Designer
-    baseSalary: 4206
+      - name: Lead Designer
+        baseSalary: 4206
 
-  - name: Senior Designer
-    baseSalary: 4066
+      - name: Senior Designer
+        baseSalary: 4066
 
-  - name: Designer
-    baseSalary: 3119
+      - name: Designer
+        baseSalary: 3119
 
-  - name: Junior Designer
-    baseSalary: 2649
+      - name: Junior Designer
+        baseSalary: 2649
 
-  - name: Senior Operations Manager
-    baseSalary: 3903
+  - name: Operations
+    roles:
+      - name: Senior Operations Manager
+        baseSalary: 3903
 
-  - name: Operations Manager
-    baseSalary: 2720
+      - name: Operations Manager
+        baseSalary: 2720
 
-  - name: Technical Support Specialist
-    baseSalary: 1979
+      - name: Technical Support Specialist
+        baseSalary: 1979
 
-  - name: Customer Support Associate
-    baseSalary: 1792
+      - name: Customer Support Associate
+        baseSalary: 1792
 
-  - name: Customer Support Specialist
-    baseSalary: 1711
+      - name: Customer Support Specialist
+        baseSalary: 1711

--- a/elm.json
+++ b/elm.json
@@ -12,6 +12,7 @@
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
             "elm-community/maybe-extra": "5.0.0",
+            "elm-community/result-extra": "2.2.1",
             "rundis/elm-bootstrap": "5.1.0"
         },
         "indirect": {

--- a/elm.json
+++ b/elm.json
@@ -9,21 +9,21 @@
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
             "elm/url": "1.0.0",
             "elm-community/maybe-extra": "5.0.0",
             "rundis/elm-bootstrap": "5.1.0"
         },
         "indirect": {
             "avh4/elm-color": "1.0.0",
-            "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.1",
-            "elm-community/list-extra": "8.1.0"
+            "elm-community/list-extra": "8.1.0",
+            "elm-explorations/test": "1.2.1"
         },
         "indirect": {
             "elm/random": "1.0.0",

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -12,6 +12,7 @@ module SalaryCalculator exposing
     , main
     , salary
     , update
+    , viewPluralizedYears
     )
 
 import Bootstrap.Accordion as Accordion

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -3,6 +3,7 @@ module SalaryCalculator exposing
     , Role
     , commitmentBonus
     , humanizeCommitmentBonus
+    , humanizeTenure
     , init
     , lookupByName
     , main
@@ -271,8 +272,8 @@ commitmentBonus years =
     logBase e (toFloat years + 1) / 10
 
 
-tenureDescription : Int -> String
-tenureDescription years =
+humanizeTenure : Int -> String
+humanizeTenure years =
     if years < 1 then
         "Just started"
 
@@ -427,8 +428,7 @@ viewHeader model =
 
         tenureItem years =
             Dropdown.buttonItem [ onClick (TenureSelected years) ]
-                [ text (tenureDescription years)
-                ]
+                [ humanizeTenure years |> text ]
     in
     [ p [ class "lead" ]
         [ text "I'm a "

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -1,6 +1,7 @@
 module SalaryCalculator exposing
     ( City
     , Role
+    , commitmentBonus
     , init
     , main
     , salary

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -59,7 +59,9 @@ init flags =
 
         roles : Dict String Role
         roles =
-            flags.config.roles
+            flags.config.careers
+                |> List.map .roles
+                |> List.concat
                 |> List.foldl
                     (\role dict -> Dict.insert role.name role dict)
                     Dict.empty
@@ -100,6 +102,12 @@ type alias Flags =
 
 type alias Config =
     { cities : List City
+    , careers : List Career
+    }
+
+
+type alias Career =
+    { name : String
     , roles : List Role
     }
 
@@ -287,35 +295,13 @@ viewHeader model =
                         |> text
                     ]
             , items =
-                model.config.roles
-                    |> List.map roleItem
-
-            -- TODO: Career groups
-            -- [ Dropdown.header [ text "Design Career" ]
-            -- , roleItem JuniorDesigner
-            -- , roleItem Designer
-            -- , roleItem SeniorDesigner
-            -- , roleItem LeadDesigner
-            -- , roleItem PrincipalDesigner
-            -- , Dropdown.header [ text "Marketing Career" ]
-            -- , roleItem MarketingAssociate
-            -- , roleItem DigitalMarketingSpecialist
-            -- , roleItem SeniorDigitalMarketingSpecialist
-            -- , roleItem ProductMarketingManager
-            -- , roleItem SeniorProductMarketingManager
-            -- , Dropdown.header [ text "Operations Career" ]
-            -- , roleItem CustomerSupportSpecialist
-            -- , roleItem CustomerSupportAssociate
-            -- , roleItem TechnicalSupportSpecialist
-            -- , roleItem OperationsManager
-            -- , roleItem SeniorOperationsManager
-            -- , Dropdown.header [ text "Technical Career" ]
-            -- , roleItem JuniorProgrammer
-            -- , roleItem JuniorSoftwareEngineer
-            -- , roleItem SoftwareEngineer
-            -- , roleItem LeadSoftwareEngineer
-            -- , roleItem PrincipalSoftwareEngineer
-            -- ]
+                model.config.careers
+                    |> List.map
+                        (\{ name, roles } ->
+                            Dropdown.header [ text (name ++ " Career") ]
+                                :: List.map roleItem roles
+                        )
+                    |> List.concat
             }
         , text " living in "
         , Dropdown.dropdown model.cityDropdown

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -1,5 +1,6 @@
 module SalaryCalculator exposing
-    ( City
+    ( Career
+    , City
     , Field(..)
     , Flags
     , Msg(..)
@@ -54,7 +55,7 @@ init flags =
         model =
             case Decode.decodeValue configDecoder flags.config of
                 Err error ->
-                    { error = Just error
+                    { error = Just (Decode.errorToString error)
                     , warnings = []
                     , cities = []
                     , careers = []
@@ -169,6 +170,14 @@ configDecoder =
 citiesDecoder : Decode.Decoder (List City)
 citiesDecoder =
     Decode.list cityDecoder
+        |> Decode.andThen
+            (\cities ->
+                if List.length cities == 0 then
+                    Decode.fail "There must be at least one city in your config."
+
+                else
+                    Decode.succeed cities
+            )
 
 
 cityDecoder : Decode.Decoder City
@@ -181,6 +190,14 @@ cityDecoder =
 careersDecoder : Decode.Decoder (List Career)
 careersDecoder =
     Decode.list careerDecoder
+        |> Decode.andThen
+            (\careers ->
+                if List.length careers == 0 then
+                    Decode.fail "There must be at least one career in your config."
+
+                else
+                    Decode.succeed careers
+            )
 
 
 careerDecoder : Decode.Decoder Career
@@ -193,6 +210,14 @@ careerDecoder =
 rolesDecoder : Decode.Decoder (List Role)
 rolesDecoder =
     Decode.list roleDecoder
+        |> Decode.andThen
+            (\roles ->
+                if List.length roles == 0 then
+                    Decode.fail "There must be at least one role in your config."
+
+                else
+                    Decode.succeed roles
+            )
 
 
 roleDecoder : Decode.Decoder Role
@@ -261,7 +286,7 @@ type alias Warning =
 
 
 type alias Model =
-    { error : Maybe Decode.Error
+    { error : Maybe String
     , warnings : List Warning
     , careers : List Career
     , cities : List City
@@ -365,7 +390,6 @@ view model =
     case model.error of
         Just error ->
             error
-                |> Decode.errorToString
                 |> (++) "App initialization failed: "
                 |> text
 

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -1,6 +1,9 @@
 module SalaryCalculator exposing
     ( City
+    , Field(..)
+    , Msg(..)
     , Role
+    , Warning
     , commitmentBonus
     , humanizeCommitmentBonus
     , humanizeTenure
@@ -8,6 +11,7 @@ module SalaryCalculator exposing
     , lookupByName
     , main
     , salary
+    , update
     )
 
 import Bootstrap.Accordion as Accordion

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -13,6 +13,8 @@ module SalaryCalculator exposing
     , salary
     , update
     , viewPluralizedYears
+    , viewSalary
+    , viewWarnings
     )
 
 import Bootstrap.Accordion as Accordion
@@ -499,7 +501,7 @@ viewHeader model =
         , viewPluralizedYears model.tenure
         ]
     , p [ class "lead" ]
-        [ viewSalary model
+        [ viewSalary model.role model.city model.tenure
         ]
     ]
 
@@ -516,9 +518,9 @@ viewPluralizedYears years =
         text " years."
 
 
-viewSalary : Model -> Html Msg
-viewSalary model =
-    case ( model.role, model.city ) of
+viewSalary : Maybe Role -> Maybe City -> Int -> Html Msg
+viewSalary maybeRole maybeCity tenure =
+    case ( maybeRole, maybeCity ) of
         ( Nothing, Nothing ) ->
             text "Please select a role and a city."
 
@@ -532,10 +534,11 @@ viewSalary model =
             span []
                 [ text "My monthly gross salary is "
                 , span [ class "font-weight-bold" ]
-                    [ salary role city model.tenure
+                    [ (salary role city tenure
                         |> String.fromInt
+                      )
+                        ++ " €"
                         |> text
-                    , text " €"
                     ]
                 , text "."
                 ]

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -14,7 +14,6 @@ import Bootstrap.Card.Block as Block
 import Bootstrap.Dropdown as Dropdown
 import Bootstrap.ListGroup as ListGroup
 import Browser
-import Dict exposing (Dict)
 import Html exposing (Html, div, mark, p, span, table, td, text, tr)
 import Html.Attributes exposing (class, rowspan)
 import Html.Events exposing (onClick)
@@ -101,13 +100,16 @@ init flags =
                                 Nothing ->
                                     Ok (List.head roles)
 
+                        city : Result Warning (Maybe City)
                         city =
                             case query.city of
                                 Just cityName ->
                                     lookupByName cityName config.cities
+                                        |> Result.fromMaybe ("Invalid city: " ++ cityName)
+                                        |> Result.map Just
 
                                 Nothing ->
-                                    List.head config.cities
+                                    Ok (List.head config.cities)
 
                         warnings =
                             [ case role of
@@ -130,7 +132,7 @@ init flags =
                     , cities = config.cities
                     , careers = config.careers
                     , role = role |> Result.extract (\_ -> Nothing)
-                    , city = city
+                    , city = city |> Result.extract (\_ -> Nothing)
                     , tenure =
                         query.years
                             |> Maybe.withDefault 2

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -1,6 +1,7 @@
 module SalaryCalculator exposing
     ( City
     , Field(..)
+    , Flags
     , Msg(..)
     , Role
     , Warning

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -4,6 +4,7 @@ module SalaryCalculator exposing
     , commitmentBonus
     , humanizeCommitmentBonus
     , init
+    , lookupByName
     , main
     , salary
     )

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -2,6 +2,7 @@ module SalaryCalculator exposing
     ( City
     , Role
     , commitmentBonus
+    , humanizeCommitmentBonus
     , init
     , main
     , salary
@@ -534,6 +535,16 @@ viewSalary model =
                 ]
 
 
+humanizeCommitmentBonus : Float -> String
+humanizeCommitmentBonus bonus =
+    (bonus
+        |> (*) 100
+        |> round
+        |> String.fromInt
+    )
+        ++ "%"
+
+
 viewBreakdown : Role -> City -> Int -> Html Msg
 viewBreakdown role city tenure =
     div []
@@ -595,8 +606,7 @@ viewBreakdown role city tenure =
                     ]
                     [ tenure
                         |> commitmentBonus
-                        |> toPrecision 2
-                        |> String.fromFloat
+                        |> humanizeCommitmentBonus
                         |> text
                     ]
                 , td
@@ -653,21 +663,6 @@ viewBreakdown role city tenure =
                 ]
             ]
         ]
-
-
-toPrecision : Int -> Float -> Float
-toPrecision precision number =
-    let
-        factor =
-            precision
-                |> toFloat
-                |> (^) 10
-    in
-    number
-        * factor
-        |> Basics.truncate
-        |> toFloat
-        |> (\n -> n / factor)
 
 
 

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -86,18 +86,28 @@ init flags =
                             config.careers
                                 |> List.map .roles
                                 |> List.concat
+
+                        role =
+                            case query.role of
+                                Just roleName ->
+                                    lookupByName roleName roles
+
+                                Nothing ->
+                                    List.head roles
+
+                        city =
+                            case query.city of
+                                Just cityName ->
+                                    lookupByName cityName config.cities
+
+                                Nothing ->
+                                    List.head config.cities
                     in
                     { error = Nothing
                     , cities = config.cities
                     , careers = config.careers
-                    , role =
-                        query.role
-                            |> Maybe.map (\roleName -> lookupByName roleName roles)
-                            |> Maybe.join
-                    , city =
-                        query.city
-                            |> Maybe.map (\name -> lookupByName name config.cities)
-                            |> Maybe.join
+                    , role = role
+                    , city = city
                     , tenure =
                         query.years
                             |> Maybe.withDefault 2

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -28,6 +28,13 @@ import Url.Parser.Query as QueryParser exposing (int, map3, string)
 -- MODEL
 
 
+lookupByName : String -> List { a | name : String } -> Maybe { a | name : String }
+lookupByName name rolesOrCities =
+    rolesOrCities
+        |> List.filter (\record -> record.name == name)
+        |> List.head
+
+
 init : Flags -> ( Model, Cmd Msg )
 init flags =
     let
@@ -75,33 +82,21 @@ init flags =
                                 Nothing ->
                                     { role = Nothing, city = Nothing, years = Nothing }
 
-                        roles : Dict String Role
                         roles =
-                            config
-                                |> .careers
+                            config.careers
                                 |> List.map .roles
                                 |> List.concat
-                                |> List.foldl
-                                    (\role dict -> Dict.insert role.name role dict)
-                                    Dict.empty
-
-                        cities : Dict String City
-                        cities =
-                            config.cities
-                                |> List.foldl
-                                    (\role dict -> Dict.insert role.name role dict)
-                                    Dict.empty
                     in
                     { error = Nothing
                     , cities = config.cities
                     , careers = config.careers
                     , role =
                         query.role
-                            |> Maybe.map (\name -> Dict.get name roles)
+                            |> Maybe.map (\roleName -> lookupByName roleName roles)
                             |> Maybe.join
                     , city =
                         query.city
-                            |> Maybe.map (\name -> Dict.get name cities)
+                            |> Maybe.map (\name -> lookupByName name config.cities)
                             |> Maybe.join
                     , tenure =
                         query.years

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,10 @@
     <script type="text/javascript" src="./salary-calculator.js">
     </script>
     <script type="text/javascript">
-      SalaryCalculator.init(document.getElementById("app-container"))
+      SalaryCalculator.init(
+        document.getElementById("app-container"),
+        SalaryCalculator.defaults
+      )
     </script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,12 @@
 
   </head>
   <body>
-    <div id="app-container"><!-- elm app goes here --></div>
+    <div class="container">
+      <div class="row mt-3">
+        <div id="app-container"><!-- elm app goes here --></div>
+      </div>
+    </div>
+
     <script type="text/javascript" src="./salary-calculator.js">
     </script>
     <script type="text/javascript">

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const program = Elm.SalaryCalculator
 export function init(node, config = config) {
   program.init({
       flags: {
-        url: location.href,
+        location: location.href,
         config
       },
       node

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,16 @@
 import { Elm } from "./SalaryCalculator.elm"
+import config from "../config.yml"
 
 const program = Elm.SalaryCalculator
 
-export function init(node) {
+export function init(node, config = config) {
   program.init({
-      flags: location.href,
-      node: node
+      flags: {
+        url: location.href,
+        config
+      },
+      node
   })
 }
+
+export const defaults = config

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,5 +1,6 @@
 module Tests exposing
-    (  testCommitmentBonus
+    ( testCommitmentBonus
+    ,  testHumanizeCommitmentBonus
        --, cityImpact
        --, tenureImpact
 
@@ -11,7 +12,7 @@ import Bootstrap.Dropdown as Dropdown
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import List.Extra as List
-import SalaryCalculator exposing (City, Role, commitmentBonus, salary)
+import SalaryCalculator exposing (City, Role, commitmentBonus, humanizeCommitmentBonus, salary)
 import Test exposing (..)
 
 
@@ -56,4 +57,22 @@ testCommitmentBonus =
                 commitmentBonus 15
                     |> String.fromFloat
                     |> Expect.equal "0.2772588722239781"
+        ]
+
+
+testHumanizeCommitmentBonus : Test
+testHumanizeCommitmentBonus =
+    describe "Commitment Bonus is viewed as percentages"
+        [ test "0" <|
+            \_ ->
+                humanizeCommitmentBonus 0
+                    |> Expect.equal "0%"
+        , test "0.011" <|
+            \_ ->
+                humanizeCommitmentBonus 0.011
+                    |> Expect.equal "1%"
+        , test "0.125" <|
+            \_ ->
+                humanizeCommitmentBonus 0.125
+                    |> Expect.equal "13%"
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,9 +1,7 @@
 module Tests exposing
     ( testCommitmentBonus
-    ,  testHumanizeCommitmentBonus
-       --, cityImpact
-       --, tenureImpact
-
+    , testHumanizeCommitmentBonus
+    , testLookupByName
     , testSalary
     )
 
@@ -12,7 +10,7 @@ import Bootstrap.Dropdown as Dropdown
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import List.Extra as List
-import SalaryCalculator exposing (City, Role, commitmentBonus, humanizeCommitmentBonus, salary)
+import SalaryCalculator exposing (City, Role, commitmentBonus, humanizeCommitmentBonus, lookupByName, salary)
 import Test exposing (..)
 
 
@@ -75,4 +73,18 @@ testHumanizeCommitmentBonus =
             \_ ->
                 humanizeCommitmentBonus 0.125
                     |> Expect.equal "13%"
+        ]
+
+
+testLookupByName : Test
+testLookupByName =
+    describe "Get item in list based on name"
+        [ test "item exists" <|
+            \_ ->
+                lookupByName "foo" [ { name = "foo" }, { name = "bar" } ]
+                    |> Expect.equal (Just { name = "foo" })
+        , test "item does not exist" <|
+            \_ ->
+                lookupByName "bla" [ { name = "foo" }, { name = "bar" } ]
+                    |> Expect.equal Nothing
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,5 +1,6 @@
 module Tests exposing
-    ( testCommitmentBonus
+    ( tenureImpact
+    , testCommitmentBonus
     , testHumanizeCommitmentBonus
     , testHumanizeTenure
     , testInitHappyPath
@@ -666,3 +667,89 @@ testViewWarnings =
                 |> Query.fromHtml
                 |> Query.has [ tag "div", classes [ "alert" ], text "Invalid role" ]
         )
+
+
+
+-- Generated tests
+
+
+cities =
+    [ { name = "San Francisco"
+      , locationFactor = 1.59
+      }
+    , { name = "Amsterdam"
+      , locationFactor = 1.2
+      }
+    , { name = "Lisbon"
+      , locationFactor = 0.94
+      }
+    , { name = "Ljubljana"
+      , locationFactor = 0.91
+      }
+    , { name = "Novi Sad"
+      , locationFactor = 0.81
+      }
+    , { name = "Davao"
+      , locationFactor = 0.81
+      }
+    , { name = "Delhi"
+      , locationFactor = 0.79
+      }
+    ]
+
+
+roles =
+    [ { name = "Principal Software Engineer"
+      , baseSalary = 6184
+      }
+    , { name = "Software Engineer"
+      , baseSalary = 4919
+      }
+    , { name = "Junior Software Engineer"
+      , baseSalary = 2506
+      }
+    , { name = "Junior Programmer"
+      , baseSalary = 3000
+      }
+    , { name = "Senior Product Marketing Manager"
+      , baseSalary = 6140
+      }
+    , { name = "Product Marketing Manager"
+      , baseSalary = 5243
+      }
+    , { name = "Digital Marketing Specialist"
+      , baseSalary = 2955
+      }
+    ]
+
+
+years =
+    List.range 0 24
+
+
+tenureImpact : Test
+tenureImpact =
+    let
+        tenureTest : Role -> City -> Int -> Test
+        tenureTest role city tenure =
+            let
+                title =
+                    String.join " "
+                        [ role.name
+                        , "living in"
+                        , city.name
+                        , "with tenure of"
+                        , String.fromInt tenure
+                        , "earns more than with tenure of"
+                        , String.fromInt (tenure - 1)
+                        ]
+            in
+            test title
+                (\_ ->
+                    Expect.greaterThan
+                        (salary role city tenure)
+                        (salary role city tenure + 1)
+                )
+    in
+    describe "Longer tenure always results in higher salary" <|
+        List.lift3 tenureTest roles cities years

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,6 +1,7 @@
 module Tests exposing
     ( testCommitmentBonus
     , testHumanizeCommitmentBonus
+    , testHumanizeTenure
     , testLookupByName
     , testSalary
     )
@@ -10,7 +11,7 @@ import Bootstrap.Dropdown as Dropdown
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import List.Extra as List
-import SalaryCalculator exposing (City, Role, commitmentBonus, humanizeCommitmentBonus, lookupByName, salary)
+import SalaryCalculator exposing (City, Role, commitmentBonus, humanizeCommitmentBonus, humanizeTenure, lookupByName, salary)
 import Test exposing (..)
 
 
@@ -87,4 +88,22 @@ testLookupByName =
             \_ ->
                 lookupByName "bla" [ { name = "foo" }, { name = "bar" } ]
                     |> Expect.equal Nothing
+        ]
+
+
+testHumanizeTenure : Test
+testHumanizeTenure =
+    describe "Tenure has a properly pluralized 'years' suffix"
+        [ test "0" <|
+            \_ ->
+                humanizeTenure 0
+                    |> Expect.equal "Just started"
+        , test "0.011" <|
+            \_ ->
+                humanizeTenure 1
+                    |> Expect.equal "1 year"
+        , test "0.125" <|
+            \_ ->
+                humanizeTenure 5
+                    |> Expect.equal "5 years"
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,8 +1,9 @@
 module Tests exposing
-    ( cityImpact
-    , commitmentBonus
-    , defaultSalary
-    , tenureImpact
+    (  testCommitmentBonus
+       --, cityImpact
+       --, tenureImpact
+
+    , testSalary
     )
 
 import Bootstrap.Accordion as Accordion
@@ -10,211 +11,49 @@ import Bootstrap.Dropdown as Dropdown
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import List.Extra as List
-import SalaryCalculator exposing (City(..), Role(..), salary, tenureDetail)
+import SalaryCalculator exposing (City, Role, commitmentBonus, salary)
 import Test exposing (..)
 
 
-defaultSalary : Test
-defaultSalary =
+testSalary : Test
+testSalary =
     test "Salary for Software Engineer from Ljubljana with a 2 year tenure"
         (\_ ->
-            salary
-                { roleDropdown = Dropdown.initialState
-                , cityDropdown = Dropdown.initialState
-                , tenureDropdown = Dropdown.initialState
-                , accordionState = Accordion.initialState
-                , role = SoftwareEngineer
-                , city = Ljubljana
-                , tenure = 2
-                }
+            salary { name = "FooRole", baseSalary = 4919 } { name = "FooCity", locationFactor = 0.91 } 2
                 |> Expect.equal 5017
         )
 
 
-commitmentBonus : Test
-commitmentBonus =
+testCommitmentBonus : Test
+testCommitmentBonus =
     describe "Commitment Bonus is calculated correctly"
         [ test "0 years" <|
             \_ ->
-                tenureDetail 0
-                    |> Expect.equal { name = "Just started", commitmentBonus = 0 }
+                commitmentBonus 0
+                    |> Expect.equal 0
         , test "1 year" <|
             \_ ->
-                tenureDetail 1
-                    |> Expect.equal { name = "1 year", commitmentBonus = 0.06931471805599453 }
+                commitmentBonus 1
+                    |> String.fromFloat
+                    |> Expect.equal "0.06931471805599453"
         , test "2 year" <|
             \_ ->
-                tenureDetail 2
-                    |> Expect.equal { name = "2 years", commitmentBonus = 0.10986122886681096 }
+                commitmentBonus 2
+                    |> String.fromFloat
+                    |> Expect.equal "0.10986122886681096"
         , test "5 year" <|
             \_ ->
-                tenureDetail 5
-                    |> Expect.equal { name = "5 years", commitmentBonus = 0.1791759469228055 }
+                commitmentBonus 5
+                    |> String.fromFloat
+                    |> Expect.equal "0.1791759469228055"
         , test "10 year" <|
             \_ ->
-                tenureDetail 10
-                    |> Expect.equal { name = "10 years", commitmentBonus = 0.23978952727983707 }
+                commitmentBonus 10
+                    |> String.fromFloat
+                    |> Expect.equal "0.23978952727983707"
         , test "15 year" <|
             \_ ->
-                tenureDetail 15
-                    |> Expect.equal { name = "15 years", commitmentBonus = 0.2772588722239781 }
+                commitmentBonus 15
+                    |> String.fromFloat
+                    |> Expect.equal "0.2772588722239781"
         ]
-
-
-{-| Note: Cities are ordered from most to least expensive. This is significant for the cityImpact test below.
--}
-cities =
-    [ SanFrancisco
-    , London
-    , Amsterdam
-    , Berlin
-    , Barcelona
-    , Lisbon
-    , Ljubljana
-    , Maribor
-    , Bucharest
-    , NoviSad
-    , Davao
-    , Delhi
-    , Kharkiv
-    ]
-
-
-roles =
-    [ PrincipalSoftwareEngineer
-    , LeadSoftwareEngineer
-    , SoftwareEngineer
-    , JuniorSoftwareEngineer
-    , JuniorProgrammer
-    , SeniorProductMarketingManager
-    , ProductMarketingManager
-    , SeniorDigitalMarketingSpecialist
-    , DigitalMarketingSpecialist
-    , MarketingAssociate
-    , PrincipalDesigner
-    , LeadDesigner
-    , SeniorDesigner
-    , Designer
-    , JuniorDesigner
-    , SeniorOperationsManager
-    , OperationsManager
-    , TechnicalSupportSpecialist
-    , CustomerSupportAssociate
-    , CustomerSupportSpecialist
-    ]
-
-
-years =
-    List.range 0 24
-
-
-defaults =
-    SalaryCalculator.init "https://niteo.co/salary-calculator"
-        |> Tuple.first
-
-
-tenureImpact : Test
-tenureImpact =
-    let
-        tenureTest : Role -> City -> Int -> Test
-        tenureTest role city tenure =
-            let
-                title =
-                    String.join " "
-                        [ (SalaryCalculator.roleDetail role).name
-                        , "living in"
-                        , (SalaryCalculator.cityDetail city).name
-                        , "with tenure of"
-                        , String.fromInt tenure
-                        , "earns more than with tenure of"
-                        , String.fromInt (tenure - 1)
-                        ]
-            in
-            test title
-                (\_ ->
-                    Expect.greaterThan
-                        (salary { defaults | role = role, tenure = tenure })
-                        (salary { defaults | role = role, tenure = tenure + 1 })
-                )
-    in
-    describe "Longer tenure always results in" <|
-        List.lift3 tenureTest roles cities years
-
-
-{-| Note: This suit depends on cities list above being ordered from most to least expenisve.
--}
-cityImpact : Test
-cityImpact =
-    let
-        personaSuit : ( Role, Int ) -> Test
-        personaSuit ( role, tenure ) =
-            let
-                title =
-                    [ (SalaryCalculator.roleDetail role).name
-                    , "with a tenure of"
-                    , String.fromInt tenure
-                    , "years..."
-                    ]
-                        |> String.join " "
-            in
-            cities
-                |> pairs
-                |> List.map (citiesTest role tenure)
-                |> describe title
-
-        personas : List ( Role, Int )
-        personas =
-            List.lift2 Tuple.pair roles years
-
-        citiesTest : Role -> Int -> ( City, City ) -> Test
-        citiesTest role tenure ( a, b ) =
-            let
-                title =
-                    [ "...living in"
-                    , (SalaryCalculator.cityDetail a).name
-                    , "earns at least as much as if she would live in"
-                    , (SalaryCalculator.cityDetail b).name
-                    ]
-                        |> String.join " "
-            in
-            test title <|
-                \() ->
-                    Expect.atLeast
-                        (salary
-                            { defaults
-                                | role = role
-                                , tenure = tenure
-                                , city = b
-                            }
-                        )
-                        (salary
-                            { defaults
-                                | role = role
-                                , tenure = tenure
-                                , city = a
-                            }
-                        )
-    in
-    describe "Salaries are higher in more expensive cities" <|
-        List.map personaSuit personas
-
-
-{-| Helper that given a list of elements returns a list of tuples with two neighboring elements
-
-    pairs [ SanFrancisco, London, Amsterdam, Berlin ]
-    -- [( SanFrancisco, London ), ( London, Amsterdam ), ( Amsterdam, Berlin )]
-
-Used for comparing salaries in different cities.
-
--}
-pairs : List a -> List ( a, a )
-pairs list =
-    case list of
-        [] ->
-            []
-
-        a :: [] ->
-            []
-
-        a :: b :: rest ->
-            ( a, b ) :: pairs (b :: rest)

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -4,15 +4,19 @@ module Tests exposing
     , testHumanizeTenure
     , testLookupByName
     , testSalary
+    , testViewPluralizedYears
     )
 
 import Bootstrap.Accordion as Accordion
 import Bootstrap.Dropdown as Dropdown
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
+import Html
 import List.Extra as List
-import SalaryCalculator exposing (City, Field(..), Msg(..), Role, Warning, commitmentBonus, humanizeCommitmentBonus, humanizeTenure, lookupByName, salary, update)
+import SalaryCalculator exposing (City, Field(..), Msg(..), Role, Warning, commitmentBonus, humanizeCommitmentBonus, humanizeTenure, lookupByName, salary, update, viewPluralizedYears)
 import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (tag, text)
 
 
 testSalary : Test
@@ -148,4 +152,25 @@ hideWarnings =
                     |> Tuple.first
                     |> .warnings
                     |> Expect.equal [ Warning "foo" RoleField ]
+        ]
+
+
+testViewPluralizedYears : Test
+testViewPluralizedYears =
+    describe "HTML for tenure dropdown suffix"
+        [ test "0" <|
+            \_ ->
+                viewPluralizedYears 0
+                    |> Query.fromHtml
+                    |> Query.has [ text " years." ]
+        , test "1" <|
+            \_ ->
+                viewPluralizedYears 1
+                    |> Query.fromHtml
+                    |> Query.has [ text " year." ]
+        , test "5" <|
+            \_ ->
+                viewPluralizedYears 5
+                    |> Query.fromHtml
+                    |> Query.has [ text " years." ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -11,7 +11,7 @@ import Bootstrap.Dropdown as Dropdown
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import List.Extra as List
-import SalaryCalculator exposing (City, Role, commitmentBonus, humanizeCommitmentBonus, humanizeTenure, lookupByName, salary)
+import SalaryCalculator exposing (City, Field(..), Msg(..), Role, Warning, commitmentBonus, humanizeCommitmentBonus, humanizeTenure, lookupByName, salary, update)
 import Test exposing (..)
 
 
@@ -106,4 +106,46 @@ testHumanizeTenure =
             \_ ->
                 humanizeTenure 5
                     |> Expect.equal "5 years"
+        ]
+
+
+hideWarnings : Test
+hideWarnings =
+    describe "Warnings are hidden when role or city is selected"
+        [ test "role is selected" <|
+            \_ ->
+                update (RoleSelected (Role "foo" 5000))
+                    { error = Nothing
+                    , warnings = [ Warning "foo" RoleField, Warning "bar" CityField ]
+                    , cities = []
+                    , careers = []
+                    , role = Nothing
+                    , city = Nothing
+                    , tenure = 0
+                    , accordionState = Accordion.initialState
+                    , roleDropdown = Dropdown.initialState
+                    , cityDropdown = Dropdown.initialState
+                    , tenureDropdown = Dropdown.initialState
+                    }
+                    |> Tuple.first
+                    |> .warnings
+                    |> Expect.equal [ Warning "bar" CityField ]
+        , test "city is selected" <|
+            \_ ->
+                update (CitySelected (City "foo" 1.1))
+                    { error = Nothing
+                    , warnings = [ Warning "foo" RoleField, Warning "bar" CityField ]
+                    , cities = []
+                    , careers = []
+                    , role = Nothing
+                    , city = Nothing
+                    , tenure = 0
+                    , accordionState = Accordion.initialState
+                    , roleDropdown = Dropdown.initialState
+                    , cityDropdown = Dropdown.initialState
+                    , tenureDropdown = Dropdown.initialState
+                    }
+                    |> Tuple.first
+                    |> .warnings
+                    |> Expect.equal [ Warning "foo" RoleField ]
         ]


### PR DESCRIPTION
**What is this PR about**

Extract hard-coded cities and roles data to config file. Closes #25.

**Notes**

The tests are not updated yet.

Config contains list of cities and careers with roles for each career. The file is in YAML format for readability. Convertion to JSON happens at compile time.  Data from this file is exposed in the browser as `SalaryCalculator.defaults` and can be passed to `init` as optional second argument. Alternative config can be provided the same way.

Compared to previous version there are following user facing differences:

- No role or city is initially selected 

  The salary display and the breakdown accordion are disabled until both fields are selected. IMO this is a significant improvement. If you prefer, we can make the app select the first item from each list, but we still have to handle a case of empty list. 

- The URL query parameters take full name of a role or a city

  e.g. `San Francisco` instead of `SanFrancisco` or `Customer Support Associate` instead of `CustomerSupportAssociate`.

- The careers and roles are ordered differently

  We can change the order simply by reshuffling the YAML file.