### PR TITLE
Write comments with verifiable examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ elm-stuff/
 node_modules/
 repl-temp-*
 .npmrc
+/tests/VerifyExamples
+

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,15 @@ lint: .installed
 test: tests
 
 .PHONY: tests
-tests: .installed
+tests: .installed verify-examples coverage
+
+.PHONY: coverage
+coverage: .installed
 	@npx elm-coverage --report codecov
+
+.PHONY: verify-examples
+verify-examples: .installed
+	@npx elm-verify-examples
 
 .coverage/codecov.json: .installed test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3658,6 +3658,698 @@
         }
       }
     },
+    "elm-verify-examples": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/elm-verify-examples/-/elm-verify-examples-3.1.0.tgz",
+      "integrity": "sha512-zNjiwP8vR83caUDKXa+BK3S9wLxLy5DB/2qDfewI5OuEevv+QwZUh1sSZbhNtkgKYdL7pLFX0s+Sp5tvAbJoCQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "elm-test": "0.19.0-rev6",
+        "fs-extra": "^5.0.0",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.2",
+        "yargs": "^10.0.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz",
+          "integrity": "sha1-glR3SrR4a4xbPPTfumbOVjkywlI=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "elm-test": {
+          "version": "0.19.0-rev6",
+          "resolved": "https://registry.npmjs.org/elm-test/-/elm-test-0.19.0-rev6.tgz",
+          "integrity": "sha512-Qdy9QusZF+eT0203XBiT1Y/UhFeUjcSuyyzf3iyp32dsYpAfcoDTWHjlBVjia1CyvFauESQ4pc81nKaq6snClg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "chokidar": "2.1.2",
+            "cross-spawn": "4.0.0",
+            "elmi-to-json": "0.19.1",
+            "find-parent-dir": "^0.3.0",
+            "firstline": "1.2.1",
+            "fs-extra": "0.30.0",
+            "fsevents": "1.2.4",
+            "glob": "7.1.1",
+            "lodash": "4.17.11",
+            "minimist": "^1.2.0",
+            "murmur-hash-js": "1.0.0",
+            "node-elm-compiler": "5.0.3",
+            "split": "1.0.1",
+            "supports-color": "4.2.0",
+            "temp": "0.8.3",
+            "which": "1.3.1",
+            "xmlbuilder": "^8.2.2"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+              "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+              }
+            },
+            "fs-extra": {
+              "version": "0.30.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+              "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
+              }
+            }
+          }
+        },
+        "elmi-to-json": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/elmi-to-json/-/elmi-to-json-0.19.1.tgz",
+          "integrity": "sha512-O0Z3YsYU9OTb1hTDGORWxi69QjQFEIPfZVq/oc1D5lhL3swduHKY8vdKGuo+WlKVdTas99oNIsgL7yojWdYcsQ==",
+          "dev": true,
+          "requires": {
+            "binwrap": "^0.2.0-rc2"
+          }
+        },
+        "firstline": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.2.1.tgz",
+          "integrity": "sha1-uIZzxCAJ+IIfrCkm6ZcgrO6ST64=",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          },
+          "dependencies": {
+            "jsonfile": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+              "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6"
+              }
+            }
+          }
+        },
+        "fsevents": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+          "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.21",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.7",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.2.4",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
+          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
+      }
+    },
     "elmi-to-json": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/elmi-to-json/-/elmi-to-json-0.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "elm-analyse": "^0.16.1",
     "elm-coverage": "^0.2.0",
     "elm-hot": "^1.0.1",
+    "elm-verify-examples": "^3.1.0",
     "node-elm-compiler": "^5.0.3",
     "parcel-bundler": "^1.12.0"
   }

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -56,7 +56,8 @@ import Url.Parser.Query as QueryParser exposing (int, map3, string)
 -- MODEL
 
 
-{-| Given a list of records with a name field returns first item with a matching name. If no item has a matching name then returns Nothing.
+{-| Given a list of records with a name field returns first item with a
+matching name. If no item has a matching name then returns Nothing.
 
     lookupByName "Amsterdam"
         [ { name = "Amsterdam", locationFactor = 1.4 }
@@ -136,7 +137,14 @@ init flags =
                             case query.role of
                                 Just roleName ->
                                     lookupByName roleName roles
-                                        |> Result.fromMaybe (Warning ("Invalid role provided via URL: " ++ roleName ++ ". Please choose one from the dropdown below.") RoleField)
+                                        |> Result.fromMaybe
+                                            (Warning
+                                                ("Invalid role provided via URL: "
+                                                    ++ roleName
+                                                    ++ ". Please choose one from the dropdown below."
+                                                )
+                                                RoleField
+                                            )
                                         |> Result.map Just
 
                                 Nothing ->
@@ -147,7 +155,14 @@ init flags =
                             case query.city of
                                 Just cityName ->
                                     lookupByName cityName config.cities
-                                        |> Result.fromMaybe (Warning ("Invalid city provided via URL: " ++ cityName ++ ". Please choose one from the dropdown below.") CityField)
+                                        |> Result.fromMaybe
+                                            (Warning
+                                                ("Invalid city provided via URL: "
+                                                    ++ cityName
+                                                    ++ ". Please choose one from the dropdown below."
+                                                )
+                                                CityField
+                                            )
                                         |> Result.map Just
 
                                 Nothing ->

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -466,7 +466,9 @@ type alias Model =
 
     Ok (commitmentBonus 3)
     --> Ok 0.13862943611198905
-    -- Note: the value is tagged with `Ok` (i.e. wrapped in a `Result` type) to bypass a limitation of Elm Verify Examples. See https://github.com/stoeffel/elm-verify-examples/issues/83
+    -- Note: the value is tagged with `Ok` (i.e. wrapped in a `Result` type) to
+    -- bypass a limitation of Elm Verify Examples.
+    -- See https://github.com/stoeffel/elm-verify-examples/issues/83
 
 -}
 commitmentBonus : Int -> Float
@@ -509,7 +511,12 @@ humanizeTenure years =
 -}
 salary : Role -> City -> Int -> Int
 salary role city tenure =
-    round (role.baseSalary * city.locationFactor + role.baseSalary * commitmentBonus tenure)
+    round
+        (role.baseSalary
+            * city.locationFactor
+            + role.baseSalary
+            * commitmentBonus tenure
+        )
 
 
 
@@ -596,7 +603,12 @@ view model =
                                 Accordion.header []
                                     (Accordion.toggle [ class "p-0" ]
                                         [ span []
-                                            [ if model.role /= Nothing && model.city /= Nothing then
+                                            [ if
+                                                model.role
+                                                    /= Nothing
+                                                    && model.city
+                                                    /= Nothing
+                                              then
                                                 text "Okay, let's break that down ..."
 
                                               else
@@ -747,7 +759,8 @@ viewPluralizedYears years =
         text " years."
 
 
-{-| Displays monthly salary when provided with role and city. Otherwise displays a prompt for missing data.
+{-| Displays monthly salary when provided with role and city. Otherwise
+displays a prompt for missing data.
 
     import Html
 
@@ -883,10 +896,18 @@ viewBreakdown role city tenure =
                     [ text ")" ]
                 ]
             , tr []
-                [ td [ class "border-0 p-0 text-center text-muted" ] [ text "(base salary)" ]
-                , td [ class "border-0 p-0 text-center text-muted" ] [ text "(location factor)" ]
-                , td [ class "border-0 p-0 text-center text-muted" ] [ text "(base salary)" ]
-                , td [ class "border-0 p-0 text-center text-muted" ] [ text "(commitment bonus)" ]
+                [ td
+                    [ class "border-0 p-0 text-center text-muted" ]
+                    [ text "(base salary)" ]
+                , td
+                    [ class "border-0 p-0 text-center text-muted" ]
+                    [ text "(location factor)" ]
+                , td
+                    [ class "border-0 p-0 text-center text-muted" ]
+                    [ text "(base salary)" ]
+                , td
+                    [ class "border-0 p-0 text-center text-muted" ]
+                    [ text "(commitment bonus)" ]
                 ]
             ]
         , ListGroup.ul

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -466,7 +466,7 @@ type alias Model =
 
     Ok (commitmentBonus 3)
     --> Ok 0.13862943611198905
-    -- Note: the value is tagged with `Ok` (i.e. wrapped in a `Result` type) to bypass a limitation of Elm Verify Examples. See ...
+    -- Note: the value is tagged with `Ok` (i.e. wrapped in a `Result` type) to bypass a limitation of Elm Verify Examples. See https://github.com/stoeffel/elm-verify-examples/issues/83
 
 -}
 commitmentBonus : Int -> Float
@@ -797,6 +797,9 @@ viewSalary maybeRole maybeCity tenure =
 
     humanizeCommitmentBonus 0.126
     --> "13%"
+
+    humanizeCommitmentBonus 3.0
+    --> "300%"
 
 -}
 humanizeCommitmentBonus : Float -> String

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -1,0 +1,4 @@
+{
+  "root": "../src/",
+  "tests": [ "SalaryCalculator" ]
+}


### PR DESCRIPTION
Some functions and decoders are covered by doc-tests (examples with expected return values). The tests are performed as part of Make targets: verify-examples and tests.

Some more complex cases (like viewSalary with all data provided) were intentionally ommited. The examples are primarily for human readers, so they shouldn't be too complex. If we need to test these complex scenarios, we should use unit or integration tests.

**Notes**

This PR supersedes #22 

Unfortunately the doc tests currently do not get counted in coverage report. This is due to how Elm Validate Examples work. To change this first that issue would have to be addressed: https://github.com/stoeffel/elm-verify-examples/issues/65

Another improvement would be to follow the advise here https://github.com/elm-explorations/test/tree/1.2.1#application-specific-techniques and not expose all the internal helpers from Main module. We could create several specialized modules like `Salary`, `City`, `Tenure` or just one `Internal` with everything exposed and one `Main` which would only expose `main`. IMO this goes beyond the scope of this PR. Maybe we should make an issue for that?