### PR TITLE
Split modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,5 +66,5 @@ publish: dist
 
 # Nuke from orbit
 clean:
-	@rm -rf elm-stuff/ dist/ node_modules/
+	@rm -rf elm-stuff/ dist/ node_modules/ tests/VerifyExamples/
 	@rm -f .installed

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-sources := "$(shell find src -type f | sort | xargs ls -l)"
-
 .PHONY: all
 all: .installed lint test dist
 

--- a/src/Career.elm
+++ b/src/Career.elm
@@ -1,0 +1,16 @@
+module Career exposing
+    ( Career
+    , Role
+    )
+
+
+type alias Role =
+    { name : String
+    , baseSalary : Float
+    }
+
+
+type alias Career =
+    { name : String
+    , roles : List Role
+    }

--- a/src/City.elm
+++ b/src/City.elm
@@ -1,0 +1,7 @@
+module City exposing (City)
+
+
+type alias City =
+    { name : String
+    , locationFactor : Float
+    }

--- a/src/Config.elm
+++ b/src/Config.elm
@@ -1,0 +1,228 @@
+module Config exposing
+    ( Config
+    , careerDecoder
+    , careersDecoder
+    , citiesDecoder
+    , cityDecoder
+    , configDecoder
+    , roleDecoder
+    , rolesDecoder
+    )
+
+import Career exposing (Career, Role)
+import City exposing (City)
+import Json.Decode as Decode
+
+
+type alias Config =
+    { cities : List City
+    , careers : List Career
+    }
+
+
+{-| Used in `init` function to decode config passed in `Flags`
+
+    import Json.Decode as Decode
+    import City exposing (City)
+    import Career exposing (Role, Career)
+
+    Decode.decodeString configDecoder """
+      {
+        "cities" : [
+          {
+            "name": "Keren",
+            "locationFactor": 1.87
+          }
+        ],
+        "careers" : [
+          {
+            "name": "Design",
+            "roles": [
+              {
+                "name": "Junior Designer",
+                "baseSalary": 2345
+              }
+            ]
+          }
+        ]
+      }
+    """
+    --> Ok
+    -->     { cities = [ City "Keren" 1.87 ]
+    -->     , careers =
+    -->         [ Career "Design"
+    -->             [ Role "Junior Designer" 2345 ]
+    -->         ]
+    -->     }
+
+-}
+configDecoder : Decode.Decoder Config
+configDecoder =
+    Decode.map2
+        Config
+        (Decode.field "cities" citiesDecoder)
+        (Decode.field "careers" careersDecoder)
+
+
+{-| A helper for configDecoder
+
+    import City exposing (City)
+    import Json.Decode as Decode
+
+    Decode.decodeString citiesDecoder """
+      [
+        {
+          "name": "Keren",
+          "locationFactor": 1.87
+        }
+      ]
+    """
+    --> Ok [ City "Keren" 1.87 ]
+
+-}
+citiesDecoder : Decode.Decoder (List City)
+citiesDecoder =
+    Decode.list cityDecoder
+        |> Decode.andThen
+            (\cities ->
+                if List.length cities == 0 then
+                    Decode.fail "There must be at least one city in your config."
+
+                else
+                    Decode.succeed cities
+            )
+
+
+{-| A helper for configDecoder
+
+    import City exposing (City)
+    import Json.Decode as Decode
+
+    Decode.decodeString cityDecoder """
+      {
+        "name": "Keren",
+        "locationFactor": 1.87
+      }
+    """
+    --> Ok (City "Keren" 1.87)
+
+-}
+cityDecoder : Decode.Decoder City
+cityDecoder =
+    Decode.map2 City
+        (Decode.field "name" Decode.string)
+        (Decode.field "locationFactor" Decode.float)
+
+
+{-| A helper for configDecoder
+
+    import Career exposing (Career, Role)
+    import Json.Decode as Decode
+
+    Decode.decodeString careersDecoder """
+      [
+        {
+          "name": "Design",
+          "roles": [
+            {
+              "name": "Junior Designer",
+              "baseSalary": 2345
+            }
+          ]
+        }
+      ]
+    """
+    --> Ok [ Career "Design" [ Role "Junior Designer" 2345 ] ]
+
+-}
+careersDecoder : Decode.Decoder (List Career)
+careersDecoder =
+    Decode.list careerDecoder
+        |> Decode.andThen
+            (\careers ->
+                if List.length careers == 0 then
+                    Decode.fail "There must be at least one career in your config."
+
+                else
+                    Decode.succeed careers
+            )
+
+
+{-| A helper for configDecoder
+
+    import Career exposing (Career, Role)
+    import Json.Decode as Decode
+
+    Decode.decodeString careerDecoder """
+      {
+        "name": "Design",
+        "roles": [
+          {
+            "name": "Junior Designer",
+            "baseSalary": 2345
+          }
+        ]
+      }
+    """
+    --> Ok
+    -->     (Career "Design"
+    -->         [ Role "Junior Designer" 2345 ]
+    -->     )
+
+-}
+careerDecoder : Decode.Decoder Career
+careerDecoder =
+    Decode.map2
+        Career
+        (Decode.field "name" Decode.string)
+        (Decode.field "roles" rolesDecoder)
+
+
+{-| A helper for configDecoder
+
+    import Json.Decode as Decode
+    import Career exposing (Role)
+
+    Decode.decodeString rolesDecoder """
+      [
+        {
+          "name": "Junior Designer",
+          "baseSalary": 2345
+        }
+      ]
+    """
+    --> Ok [ Role "Junior Designer" 2345 ]
+
+-}
+rolesDecoder : Decode.Decoder (List Role)
+rolesDecoder =
+    Decode.list roleDecoder
+        |> Decode.andThen
+            (\roles ->
+                if List.length roles == 0 then
+                    Decode.fail "There must be at least one role in your config."
+
+                else
+                    Decode.succeed roles
+            )
+
+
+{-| A helper for configDecoder
+
+    import Career exposing (Role)
+    import Json.Decode as Decode
+
+    Decode.decodeString roleDecoder """
+      {
+        "name": "Junior Designer",
+        "baseSalary": 2345
+      }
+    """
+    --> Ok (Role "Junior Designer" 2345)
+
+-}
+roleDecoder : Decode.Decoder Role
+roleDecoder =
+    Decode.map2 Role
+        (Decode.field "name" Decode.string)
+        (Decode.field "baseSalary" Decode.int |> Decode.map toFloat)

--- a/src/Salary.elm
+++ b/src/Salary.elm
@@ -1,0 +1,43 @@
+module Salary exposing
+    ( calculate
+    , commitmentBonus
+    )
+
+import Career exposing (Role)
+import City exposing (City)
+
+
+{-| Calculate a salary based on a role, city and tenure
+
+    import City exposing (City)
+    import Career exposing (Role)
+
+    calculate (Role "Designer" 2500) (City "Warsaw" 1) 0
+    --> 2500
+
+    calculate (Role "Designer" 2500) (City "Amsterdam" 1.5) 0
+    --> 3750
+
+-}
+calculate : Role -> City -> Int -> Int
+calculate role city tenure =
+    round
+        (role.baseSalary
+            * city.locationFactor
+            + role.baseSalary
+            * commitmentBonus tenure
+        )
+
+
+{-| Given a tenure returns a commitmentBonus.
+
+    Ok (commitmentBonus 3)
+    --> Ok 0.13862943611198905
+    -- Note: the value is tagged with `Ok` (i.e. wrapped in a `Result` type) to
+    -- bypass a limitation of Elm Verify Examples.
+    -- See https://github.com/stoeffel/elm-verify-examples/issues/83
+
+-}
+commitmentBonus : Int -> Float
+commitmentBonus tenure =
+    logBase e (toFloat tenure + 1) / 10

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import { Elm } from "./SalaryCalculator.elm"
+import { Elm } from "./Main.elm"
 import config from "../config.yml"
 
-const program = Elm.SalaryCalculator
+const program = Elm.Main
 
 export function init(node, config = config) {
   program.init({

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -19,32 +19,31 @@ module Tests exposing
 
 import Bootstrap.Accordion as Accordion
 import Bootstrap.Dropdown as Dropdown
+import Career exposing (Career, Role)
+import City exposing (City)
+import Config exposing (Config)
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import Html
 import Json.Decode as Decode
 import Json.Encode as Encode
 import List.Extra as List
-import SalaryCalculator
+import Main
     exposing
-        ( Career
-        , City
-        , Field(..)
+        ( Field(..)
         , Flags
         , Msg(..)
-        , Role
         , Warning
-        , commitmentBonus
         , humanizeCommitmentBonus
         , humanizeTenure
         , init
         , lookupByName
-        , salary
         , update
         , viewPluralizedYears
         , viewSalary
         , viewWarnings
         )
+import Salary
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (classes, tag, text)
@@ -469,7 +468,7 @@ testSalary =
     in
     test "Salary for Software Engineer from Ljubljana with a 2 year tenure"
         (\_ ->
-            salary role city tenure
+            Salary.calculate role city tenure
                 |> Expect.equal 5017
         )
 
@@ -512,31 +511,31 @@ testCommitmentBonus =
     describe "Commitment Bonus is calculated correctly"
         [ test "0 years" <|
             \_ ->
-                commitmentBonus 0
+                Salary.commitmentBonus 0
                     |> Expect.equal 0
         , test "1 year" <|
             \_ ->
-                commitmentBonus 1
+                Salary.commitmentBonus 1
                     |> String.fromFloat
                     |> Expect.equal "0.06931471805599453"
         , test "2 year" <|
             \_ ->
-                commitmentBonus 2
+                Salary.commitmentBonus 2
                     |> String.fromFloat
                     |> Expect.equal "0.10986122886681096"
         , test "5 year" <|
             \_ ->
-                commitmentBonus 5
+                Salary.commitmentBonus 5
                     |> String.fromFloat
                     |> Expect.equal "0.1791759469228055"
         , test "10 year" <|
             \_ ->
-                commitmentBonus 10
+                Salary.commitmentBonus 10
                     |> String.fromFloat
                     |> Expect.equal "0.23978952727983707"
         , test "15 year" <|
             \_ ->
-                commitmentBonus 15
+                Salary.commitmentBonus 15
                     |> String.fromFloat
                     |> Expect.equal "0.2772588722239781"
         ]
@@ -747,8 +746,8 @@ tenureImpact =
             test title
                 (\_ ->
                     Expect.greaterThan
-                        (salary role city tenure)
-                        (salary role city tenure + 1)
+                        (Salary.calculate role city tenure)
+                        (Salary.calculate role city tenure + 1)
                 )
     in
     describe "Longer tenure always results in higher salary" <|
@@ -794,8 +793,8 @@ cityImpact =
             test title <|
                 \() ->
                     Expect.atLeast
-                        (salary role a tenure)
-                        (salary role b tenure)
+                        (Salary.calculate role a tenure)
+                        (Salary.calculate role b tenure)
     in
     describe "Salaries are higher in more expensive cities" <|
         List.map personaSuit personas

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -1,4 +1,4 @@
 {
   "root": "../src/",
-  "tests": [ "SalaryCalculator" ]
+  "tests": [ "Salary", "Main", "Config" ]
 }


### PR DESCRIPTION
The layout is following:

- `Main`
  
  most of the code from `SalaryCalculator.elm` is here

- `Salary`

  two most important functions: `Salary.calculate` and `Salary.commimentBonus`

- `Config`

  the `Config` type and it's decoders used in `Main.init`

- `City`
  
  just the type, used all over the place

- `Career` 

  the `Carer` and `Role` types. Role could easily be separated to it's own module, but I don't think it's worth it.

So the modules are mostly based around types, except for `Main` and `Salary`. I decided to keep salary separate from the UI, because it could easily be split into an Elm package.
