### PR TITLE
Rewrite view logic without Elm Bootstrap

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,11 +12,9 @@
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
             "elm-community/maybe-extra": "5.0.0",
-            "elm-community/result-extra": "2.2.1",
-            "rundis/elm-bootstrap": "5.1.0"
+            "elm-community/result-extra": "2.2.1"
         },
         "indirect": {
-            "avh4/elm-color": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
@@ -27,9 +25,7 @@
             "elm-explorations/test": "1.2.1"
         },
         "indirect": {
-            "elm/random": "1.0.0",
-            "elm/regex": "1.0.0",
-            "elm/svg": "1.0.1"
+            "elm/random": "1.0.0"
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2844,6 +2844,15 @@
       "integrity": "sha512-C6VEX3TqVJv+OhUKMMb2mcaSuRArqvCFNItqxue81/mlfX4PWwvovE5vqocgO3AnrStyHElCRm0KNknfDttEBw==",
       "dev": true
     },
+    "elm-json": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/elm-json/-/elm-json-0.2.0.tgz",
+      "integrity": "sha512-v638kNQI0eHxuEbsCs8ybbjS455gWZrTf6po653s7ay1BNOL4yXF9pR8DT0r6NSqtU+8nYdDYOaGlNH02hKPOQ==",
+      "dev": true,
+      "requires": {
+        "binwrap": "^0.2.0"
+      }
+    },
     "elm-test": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/elm-test/-/elm-test-0.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "elm-analyse": "^0.16.1",
     "elm-coverage": "^0.2.0",
     "elm-hot": "^1.0.1",
+    "elm-json": "^0.2.0",
     "elm-verify-examples": "^3.1.0",
     "node-elm-compiler": "^5.0.3",
     "parcel-bundler": "^1.12.0"

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -42,8 +42,26 @@ module SalaryCalculator exposing
     )
 
 import Browser
-import Html exposing (..)
-import Html.Attributes exposing (..)
+import Html
+    exposing
+        ( Html
+        , button
+        , div
+        , h6
+        , li
+        , mark
+        , p
+        , span
+        , strong
+        , text
+        , ul
+        )
+import Html.Attributes
+    exposing
+        ( attribute
+        , class
+        , classList
+        )
 import Html.Events exposing (onClick)
 import Json.Decode as Decode
 import Maybe.Extra as Maybe
@@ -583,7 +601,7 @@ update msg model =
 
 
 subscriptions : Model -> Sub Msg
-subscriptions model =
+subscriptions _ =
     Sub.none
 
 
@@ -652,6 +670,7 @@ view model =
                 ]
 
 
+viewBreakdownToggle : Model -> Html Msg
 viewBreakdownToggle model =
     if
         model.role
@@ -816,6 +835,7 @@ viewTenureDropdown active tenure =
         ]
 
 
+viewRoleItem : Role -> Html Msg
 viewRoleItem role =
     button
         [ class "dropdown-item"
@@ -824,6 +844,7 @@ viewRoleItem role =
         [ text role.name ]
 
 
+viewCityItem : City -> Html Msg
 viewCityItem city =
     button
         [ class "dropdown-item"
@@ -832,6 +853,7 @@ viewCityItem city =
         [ text city.name ]
 
 
+viewTenureItem : Int -> Html Msg
 viewTenureItem tenure =
     button
         [ class "dropdown-item"
@@ -1037,7 +1059,7 @@ viewBreakdown role city tenure =
 
         viewLegendItem : String -> List (Html Msg) -> Html Msg
         viewLegendItem term definition =
-            div
+            li
                 [ class "list-group-item" ]
                 [ strong []
                     [ text term

--- a/src/SalaryCalculator.elm
+++ b/src/SalaryCalculator.elm
@@ -647,7 +647,7 @@ view model =
                     , class "collapse"
                     , classList
                         [ ( "show"
-                          , not model.breakdownVisible
+                          , model.breakdownVisible
                           )
                         ]
                     ]

--- a/src/index.html
+++ b/src/index.html
@@ -8,11 +8,17 @@
 
     <!-- Bootstrap CSS -->
     <link
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
       rel="stylesheet"
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
-      integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
       crossorigin="anonymous"
     >
+    <style type="text/css" media="all">
+        /* correction for development mode */
+        [data-elm-hot] {
+            width: 100%
+        }
+    </style>
 
   </head>
   <body>

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -17,8 +17,6 @@ module Tests exposing
     , testViewWarnings
     )
 
-import Bootstrap.Accordion as Accordion
-import Bootstrap.Dropdown as Dropdown
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import Html
@@ -116,10 +114,8 @@ testInitHappyPath =
                             , role = Just (Role "Software Developer" 3500)
                             , city = Just (City "Amsterdam" 1.3)
                             , tenure = 2
-                            , accordionState = Accordion.initialState
-                            , roleDropdown = Dropdown.initialState
-                            , cityDropdown = Dropdown.initialState
-                            , tenureDropdown = Dropdown.initialState
+                            , activeField = Nothing
+                            , breakdownVisible = False
                             }
         )
 
@@ -189,10 +185,8 @@ testInitQueryString =
                             , role = Just (Role "Junior Software Developer" 2500)
                             , city = Just (City "Berlin" 1.2)
                             , tenure = 2
-                            , accordionState = Accordion.initialState
-                            , roleDropdown = Dropdown.initialState
-                            , cityDropdown = Dropdown.initialState
-                            , tenureDropdown = Dropdown.initialState
+                            , activeField = Nothing
+                            , breakdownVisible = False
                             }
         )
 
@@ -249,8 +243,12 @@ testInitInvalidQueryString =
                         |> Expect.equal
                             { error = Nothing
                             , warnings =
-                                [ Warning "Invalid role provided via URL: Foo. Please choose one from the dropdown below." RoleField
-                                , Warning "Invalid city provided via URL: Bar. Please choose one from the dropdown below." CityField
+                                [ Warning
+                                    RoleField
+                                    "Invalid role provided via URL: Foo. Please choose one from the dropdown below."
+                                , Warning
+                                    CityField
+                                    "Invalid city provided via URL: Bar. Please choose one from the dropdown below."
                                 ]
                             , cities =
                                 [ City "Amsterdam" 1.3
@@ -265,10 +263,8 @@ testInitInvalidQueryString =
                             , role = Nothing
                             , city = Nothing
                             , tenure = 2
-                            , accordionState = Accordion.initialState
-                            , roleDropdown = Dropdown.initialState
-                            , cityDropdown = Dropdown.initialState
-                            , tenureDropdown = Dropdown.initialState
+                            , activeField = Nothing
+                            , breakdownVisible = False
                             }
         )
 
@@ -307,10 +303,8 @@ testInitMissingCities =
                             , role = Nothing
                             , city = Nothing
                             , tenure = 0
-                            , accordionState = Accordion.initialState
-                            , roleDropdown = Dropdown.initialState
-                            , cityDropdown = Dropdown.initialState
-                            , tenureDropdown = Dropdown.initialState
+                            , activeField = Nothing
+                            , breakdownVisible = False
                             }
         )
 
@@ -354,10 +348,8 @@ testInitMissingCareers =
                             , role = Nothing
                             , city = Nothing
                             , tenure = 0
-                            , accordionState = Accordion.initialState
-                            , roleDropdown = Dropdown.initialState
-                            , cityDropdown = Dropdown.initialState
-                            , tenureDropdown = Dropdown.initialState
+                            , activeField = Nothing
+                            , breakdownVisible = False
                             }
         )
 
@@ -406,10 +398,8 @@ testInitMissingRoles =
                             , role = Nothing
                             , city = Nothing
                             , tenure = 0
-                            , accordionState = Accordion.initialState
-                            , roleDropdown = Dropdown.initialState
-                            , cityDropdown = Dropdown.initialState
-                            , tenureDropdown = Dropdown.initialState
+                            , activeField = Nothing
+                            , breakdownVisible = False
                             }
         )
 
@@ -447,10 +437,8 @@ testInitInvalidConfig =
                             , role = Nothing
                             , city = Nothing
                             , tenure = 0
-                            , accordionState = Accordion.initialState
-                            , roleDropdown = Dropdown.initialState
-                            , cityDropdown = Dropdown.initialState
-                            , tenureDropdown = Dropdown.initialState
+                            , activeField = Nothing
+                            , breakdownVisible = False
                             }
         )
 
@@ -597,40 +585,45 @@ hideWarnings =
     describe "Warnings are hidden when role or city is selected"
         [ test "role is selected" <|
             \_ ->
-                update (RoleSelected (Role "foo" 5000))
+                update (RoleItemSelected (Role "foo" 5000))
                     { error = Nothing
-                    , warnings = [ Warning "foo" RoleField, Warning "bar" CityField ]
+                    , warnings =
+                        [ Warning RoleField "foo"
+                        , Warning CityField "bar"
+                        ]
                     , cities = []
                     , careers = []
                     , role = Nothing
                     , city = Nothing
                     , tenure = 0
-                    , accordionState = Accordion.initialState
-                    , roleDropdown = Dropdown.initialState
-                    , cityDropdown = Dropdown.initialState
-                    , tenureDropdown = Dropdown.initialState
+                    , activeField = Nothing
+                    , breakdownVisible = False
                     }
                     |> Tuple.first
                     |> .warnings
-                    |> Expect.equal [ Warning "bar" CityField ]
+                    |> Expect.equal [ Warning CityField "bar" ]
         , test "city is selected" <|
             \_ ->
-                update (CitySelected (City "foo" 1.1))
+                update (CityItemSelected (City "foo" 1.1))
                     { error = Nothing
-                    , warnings = [ Warning "foo" RoleField, Warning "bar" CityField ]
+                    , warnings =
+                        [ Warning RoleField "foo"
+                        , Warning CityField "bar"
+                        ]
                     , cities = []
                     , careers = []
                     , role = Nothing
                     , city = Nothing
                     , tenure = 0
-                    , accordionState = Accordion.initialState
-                    , roleDropdown = Dropdown.initialState
-                    , cityDropdown = Dropdown.initialState
-                    , tenureDropdown = Dropdown.initialState
+                    , activeField = Nothing
+                    , breakdownVisible = False
                     }
                     |> Tuple.first
                     |> .warnings
-                    |> Expect.equal [ Warning "foo" RoleField ]
+                    |> Expect.equal
+                        [ Warning RoleField
+                            "foo"
+                        ]
         ]
 
 
@@ -659,7 +652,7 @@ testViewWarnings : Test
 testViewWarnings =
     let
         warnings =
-            [ Warning "Invalid role" RoleField ]
+            [ Warning RoleField "Invalid role" ]
     in
     test "Warnings are displayed as Bootstrap alerts"
         (\_ ->


### PR DESCRIPTION
The diff is big, but I hope you can make sense of it.
**Improvements**

1. App became truly responsive - previously the breakdown formula would not break on narrow viewports and overflow them along x axis.

2. We have greater control over markup

3. Code is more readable (IMHO), alas it probably can be further improved - I worked in a hurry.

**Unintended UX differences**

I aimed for maximal visual parity with previous implementation but there are two unintended changes:

1. There is no animation when breakdown is showing / hiding
2. The "Okay, let's break it down..." toggle has additional margin

We could work it out, but IMO it actually looks better that way.

**Other significant changes**

The app now has implicit dependency on Bootstrap CSS 4.3.1 (before it was 4.0.0). Without it the breakdown formula is not laid out evenly. If this dependency is a problem then we can achieve correct layout with inline CSS, but preferably we can just upgrade Bootstrap on consuming sites.

Apart from markup changes (using standard HTML elements + bootstrap classes), some changes were required to the `Model` type and `update` function. The `Model` contains two additional fields:

1. `breakdownVisible : Bool`
2. `activeField : Maybe Field`

First one is hopefully self explanatory. The `activeField` reuses `Field` type. Previously this type was only used to tag warnings. Now it also indicates which dropdown is open. This way we have a type system guarantee that only one dropdown can be open at any time.

There is a new set of `Msg` constructors. In general they are "lower level", meaning that they describe UI events like `...Clicked` or `...ItemSelected`. In longer run this should make the code more maintainable. Elm Bootstrap messages went away. In exchange we have two simpler messages: 

1. `BreakdownToggleClicked`
2. `DropdownButtonClicked Field`

The second one takes advantage of the fact that we have 3 variable fields (role, city and tenure) and three corresponding dropdowns. These are the same fields that are used to tag warnings and active field in the model. I'm not sure if it's a good decision in long run. If the app evolves in a direction where we use more (or less) dropdowns we may have to rethink it. But for now it was a very easy implementation so I went with it.

We don't need any subscriptions, however we may re-introduce it if we are going to implement keyboard interactions (see below).

**Minor changes**

I swapped the order of arguments for `Warning` constructor. In functional programming it is good practice to have data as last argument (to enable easy currying). The message seems more data than `Field` tag, so it goes last.

I've extracted `clearWarnings` function from two lambdas we had before.

**Things I would like to improve**

In a separate PR I'd like to work on:

1. Keyboard interactions: up and down arrow keys to navigate the dropdown menus, esc to close them, etc. It works with standard Bootstrap JS, but not with mine or Elm Bootstrap integration.

2. Having smart positioning of the dropdowns taking edge of the viewport into account. Again, Bootstrap JS does it. Maybe also the height of the dropdown, so it never overflows the viewport (the list of roles is pretty long and currently you have to scroll the whole page to see the last of it).

3. ARIA attributes for accessability. Bootstrap docs and examples prescribe it but I was in a hurry and skipped it. Shame on me.
