### PR TITLE
Upgrade elm-verify-examples to 4.0.0 and verify examples using coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ lint: .installed
 test: tests
 
 .PHONY: tests
-tests: .installed verify-examples coverage
+tests: .installed coverage
 
 .PHONY: coverage
-coverage: .installed
+coverage: .installed verify-examples
 	@npx elm-coverage --report codecov
 
 .PHONY: verify-examples

--- a/package-lock.json
+++ b/package-lock.json
@@ -3659,17 +3659,17 @@
       }
     },
     "elm-verify-examples": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/elm-verify-examples/-/elm-verify-examples-3.1.0.tgz",
-      "integrity": "sha512-zNjiwP8vR83caUDKXa+BK3S9wLxLy5DB/2qDfewI5OuEevv+QwZUh1sSZbhNtkgKYdL7pLFX0s+Sp5tvAbJoCQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/elm-verify-examples/-/elm-verify-examples-4.0.0.tgz",
+      "integrity": "sha512-oKptkeUX0MBbYJ2Yn5CwaT502O8hwJHubNbeO7redshHnoaLzVvCK3TCS9+Vx1mXW8/GuJ6bfM+PDXXPPX8MNA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
+        "chalk": "^2.4.2",
         "elm-test": "0.19.0-rev6",
         "fs-extra": "^5.0.0",
         "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.2",
-        "yargs": "^10.0.3"
+        "rimraf": "^2.6.3",
+        "yargs": "^10.1.2"
       },
       "dependencies": {
         "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "elm-analyse": "^0.16.1",
     "elm-coverage": "^0.2.0",
     "elm-hot": "^1.0.1",
-    "elm-verify-examples": "^3.1.0",
+    "elm-verify-examples": "^4.0.0",
     "node-elm-compiler": "^5.0.3",
     "parcel-bundler": "^1.12.0"
   }


### PR DESCRIPTION
After https://github.com/stoeffel/elm-verify-examples/pull/84 has been released it is now possible to verify examples (i.e. run tests generated from the examples) using another tool. In our case it's elm-verify.

To make utilise it make coverage target now depends on verify-examples, which only generates test files, without running them.