### PR TITLE
Associate is lower in rank than a Specialist

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -85,10 +85,10 @@ careers:
 
   - name: Operations
     roles:
-      - name: Customer Support Specialist
+      - name: Customer Support Associate
         baseSalary: 1711
 
-      - name: Customer Support Associate
+      - name: Customer Support Specialist
         baseSalary: 1792
 
       - name: Technical Support Specialist


### PR DESCRIPTION
An associate is a person who is part of a work team or a collaborative partner towards a specific goal. However, a specialist is a person who is an expert at something and will in many instances work independently.

Source: https://careertrend.com/info-8610586-associate-versus-specialist.html